### PR TITLE
Fix persistence for generated video data

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/contexts/MarketingContext.tsx
+++ b/src/contexts/MarketingContext.tsx
@@ -235,10 +235,12 @@ export const MarketingProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   const generateVideos = async () => {
     // In a real implementation, this would call Gemini's Veo3 API
     const ideasWithVideos = mockGenerateVideos(selectedIdeas.length > 0 ? selectedIdeas : generatedIdeas.slice(0, 1));
-    setGeneratedIdeas(generatedIdeas.map(idea => {
+    const updatedIdeas = generatedIdeas.map(idea => {
       const updatedIdea = ideasWithVideos.find(i => i.id === idea.id);
       return updatedIdea || idea;
-    }));
+    });
+    setGeneratedIdeas(updatedIdeas);
+    updateCurrentCampaign({ generatedIdeas: updatedIdeas });
   };
 
   const saveCampaign = () => {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -133,5 +134,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+       plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- adjust empty interface declarations to satisfy lint
- switch Tailwind plugin loading to ES module style
- update generated videos to persist to campaign state

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684180cbe57c8327b08998e851de4899