### PR TITLE
Fix campaign loading state

### DIFF
--- a/src/contexts/MarketingContext.tsx
+++ b/src/contexts/MarketingContext.tsx
@@ -117,7 +117,7 @@ export const MarketingProvider: React.FC<{ children: React.ReactNode }> = ({ chi
       const savedCampaigns = JSON.parse(localStorage.getItem('marketingCampaigns') || '[]');
       const campaign = savedCampaigns.find((c: Campaign) => c.id === currentCampaignId);
       if (campaign) {
-        setCurrentCampaign(campaign);
+        setCurrentCampaignState(campaign);
       }
     }
   }, []);


### PR DESCRIPTION
## Summary
- ensure stored campaigns restore all state fields when loading

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684183b7024883279db803bdff366e38