### PR TITLE
Fix NotFound page routing link

### DIFF
--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,5 +1,5 @@
-import { useLocation } from "react-router-dom";
-import { useEffect } from "react";
+import { useLocation, Link } from 'react-router-dom';
+import { useEffect } from 'react';
 
 const NotFound = () => {
   const location = useLocation();
@@ -16,9 +16,9 @@ const NotFound = () => {
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
         <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
+        <Link to="/" className="text-blue-500 hover:text-blue-700 underline">
           Return to Home
-        </a>
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- use `Link` from react-router-dom in NotFound page
- keep the same styling for the return link
- match quote style with the rest of the project

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_684183b762b0832787f34bcdde4c4a39